### PR TITLE
Change to 'BSTR' properly support secureString plain text *nix OS

### DIFF
--- a/Celerium.DattoBCDR/Private/ApiKeys/Get-DattoBCDRAPIKey.ps1
+++ b/Celerium.DattoBCDR/Private/ApiKeys/Get-DattoBCDRAPIKey.ps1
@@ -49,7 +49,7 @@ function Get-DattoBCDRAPIKey {
 
                     [PSCustomObject]@{
                         PublicKey = $DattoBCDRModuleApiKey
-                        SecretKey = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto($ApiKey)).ToString()
+                        SecretKey = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ApiKey)).ToString()
                     }
                 }
                 else {


### PR DESCRIPTION
Change from 'Auto' to 'BSTR' to properly support plain text conversion in non-Windows environments

https://github.com/PowerShell/PowerShell/issues/12114#issuecomment-598192488

# Pull Request

Change to 'BSTR' properly support secureString plain text *nix OS

## Description

Provides cross-OS compatible support for module API calls.

Fixes: https://github.com/Celerium/Celerium.DattoBCDR/issues/1

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have reviewed the [Contributing](https://github.com/Celerium/Celerium.DattoBCDR/blob/main/.github/CONTRIBUTING.md) guide
- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes*

> *Current Pester tests pass in **main** with 1 failing prior to code changes.

## How Has This Been Tested?

1. [x] Made code changes and tested from source.

```pwsh
Import-Module .\Celerium.DattoBCDR\Celerium.DattoBCDR.psd1 -Force
Set-DattoBCDRAPIKey -ApiKeyPublic 123456 -ApiKeySecret abcdef
Get-DattoBCDRAPIKey -AsPlainText

PublicKey SecretKey
--------- ---------
123456    abcdef
```

2. [x] Ran local build process, imported module with code changes and confirmed changes.

```pwsh
Import-Module ./build/Celerium.DattoBCDR/1.0.1/Celerium.DattoBCDR.psd1 -Force
Set-DattoBCDRAPIKey -ApiKeyPublic 123456 -ApiKeySecret abcdef
Get-DattoBCDRAPIKey -AsPlainText

PublicKey SecretKey
--------- ---------
123456    abcdef
```

---

### Failing Pester test prior to code changes in WSL

```pwsh
./build/Invoke-PesterTests.ps1

cmdlet Invoke-PesterTests.ps1 at command pipeline position 1
Supply values for the following parameters:
version: 1.0.0

Starting discovery in 18 files.
Discovery found 2812 tests in 71s.
Running tests.
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Celerium.DattoBCDR.Tests.ps1 3.32s (3.07s|93ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/HelpComment.Tests.ps1 69.28s (7.84s|1.15s)
[-] Testing the [ notBuilt ] version of [ Celerium.DattoBCDR ] with [ PSScriptAnalyzer.tests.ps1 ].[ Celerium.DattoBCDR ] module PSScriptAnalyzer tests.[ Celerium.DattoBCDR.psd1 ].Should pass rule [ PSUseToExportFieldsInManifest ] 1.37s (1.37s|1ms)
 [0] Expected 0, but got 2.
 at ($invoke_Results | Measure-Object).Count | Should -Be 0, /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/PSScriptAnalyzer.tests.ps1:149
 at <ScriptBlock>, /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/PSScriptAnalyzer.tests.ps1:149
 [1] Expected 'Celerium.DattoBCDR.psd1 - 117', but got 117.
 at $result.Line | Should -Be "$($result.ScriptName) - $($result.Line)", /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/PSScriptAnalyzer.tests.ps1:155     
 at <ScriptBlock>, /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/PSScriptAnalyzer.tests.ps1:155
 [2] Expected strings to be the same, but they were different.
 Expected length: 29
 Actual length:   94
 Strings differ at index 0.
 Expected: 'Celerium.DattoBCDR.psd1 - 117'
 But was:  'Do not use wildcard or $null in this field. Explicitly specify a list for FunctionsToExport.  '
            ^
 at $result.Message | Should -Be "$($result.ScriptName) - $($result.Line)", /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/PSScriptAnalyzer.tests.ps1:156  
 at <ScriptBlock>, /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/PSScriptAnalyzer.tests.ps1:156
 [3] Expected 'Celerium.DattoBCDR.psd1 - 126', but got 126.
 at $result.Line | Should -Be "$($result.ScriptName) - $($result.Line)", /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/PSScriptAnalyzer.tests.ps1:155     
 at <ScriptBlock>, /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/PSScriptAnalyzer.tests.ps1:155
 [4] Expected strings to be the same, but they were different.
 Expected length: 29
 Actual length:   92
 Strings differ at index 0.
 Expected: 'Celerium.DattoBCDR.psd1 - 126'
 But was:  'Do not use wildcard or $null in this field. Explicitly specify a list for AliasesToExport.  '
            ^
 at $result.Message | Should -Be "$($result.ScriptName) - $($result.Line)", /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/PSScriptAnalyzer.tests.ps1:156  
 at <ScriptBlock>, /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/PSScriptAnalyzer.tests.ps1:156
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/ApiKeys/Add-DattoBCDRKey.Tests.ps1 692ms (583ms|14ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/ApiKeys/Get-DattoBCDRKey.Tests.ps1 823ms (719ms|25ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/ApiKeys/Remove-DattoBCDRKey.Tests.ps1 820ms (741ms|20ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/ApiKeys/Test-DattoBCDRKey.Tests.ps1 1.16s (1.1s|10ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/BaseUri/Add-DattoBaseURI.Tests.ps1 1.07s (997ms|30ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/BaseUri/Get-DattoBaseURI.Tests.ps1 1.02s (940ms|31ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/BaseUri/Remove-DattoBaseURI.Tests.ps1 1.06s (994ms|27ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/ModuleSettings/Export-DattoModuleSettings.Tests.ps1 1.41s (1.32s|37ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/ModuleSettings/Get-DattoModuleSettings.Tests.ps1 918ms (826ms|21ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/ModuleSettings/Import-DattoModuleSettings.Tests.ps1 897ms (830ms|15ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/ModuleSettings/Initialize-DattoModuleSettings.Tests.ps1 2.78s (2.72s|12ms)
[+] /mnt/c/Users/REDACTED/Documents/GitHub/Celerium.DattoBCDR/tests/Private/ModuleSettings/Remove-DattoModuleSettings.Tests.ps1 835ms (774ms|20ms)
Tests completed in 280.46s
Tests Passed: 2802, Failed: 1, Skipped: 5, Inconclusive: 0, NotRun: 4
```

### Failing Pester test prior to code changes in Windows 11

```pwsh
.\build\Invoke-PesterTests.ps1

cmdlet Invoke-PesterTests.ps1 at command pipeline position 1
Supply values for the following parameters:
version: 1.0.0

Starting discovery in 18 files.
Discovery found 2812 tests in 59.3s.
Running tests.
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Celerium.DattoBCDR.Tests.ps1 25.69s (11.72s|11.1s)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\HelpComment.Tests.ps1 33.67s (8.3s|4.25s)
[-] Testing the [ notBuilt ] version of [ Celerium.DattoBCDR ] with [ PSScriptAnalyzer.tests.ps1 ].[ Celerium.DattoBCDR ] module PSScriptAnalyzer tests.[ Celerium.DattoBCDR.psd1 ].Should pass rule [ PSUseToExportFieldsInManifest ] 931ms (928ms|2ms)
 at ($invoke_Results | Measure-Object).Count | Should -Be 0, C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\PSScriptAnalyzer.tests.ps1:149
 at <ScriptBlock>, C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\PSScriptAnalyzer.tests.ps1:149
 Expected 0, but got 2.
[-] Testing the [ notBuilt ] version of [ Celerium.DattoBCDR ] with [ PSScriptAnalyzer.tests.ps1 ].[ Celerium.DattoBCDR ] module PSScriptAnalyzer tests.[ Celerium.DattoBCDR.psd1 ].Should pass rule [ PSUseToExportFieldsInManifest ] 931ms (928ms|2ms)
 at $result.Line | Should -Be "$($result.ScriptName) - $($result.Line)", C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\PSScriptAnalyzer.tests.ps1:155
 at <ScriptBlock>, C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\PSScriptAnalyzer.tests.ps1:155
 Expected 'Celerium.DattoBCDR.psd1 - 117', but got 117.
[-] Testing the [ notBuilt ] version of [ Celerium.DattoBCDR ] with [ PSScriptAnalyzer.tests.ps1 ].[ Celerium.DattoBCDR ] module PSScriptAnalyzer tests.[ Celerium.DattoBCDR.psd1 ].Should pass rule [ PSUseToExportFieldsInManifest ] 931ms (928ms|2ms)
 at $result.Message | Should -Be "$($result.ScriptName) - $($result.Line)", C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\PSScriptAnalyzer.tests.ps1:156      
 at <ScriptBlock>, C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\PSScriptAnalyzer.tests.ps1:156
 Expected strings to be the same, but they were different.
 Expected length: 29
 Actual length:   92
 Strings differ at index 0.
 Expected: 'Celerium.DattoBCDR.psd1 - 117'
 But was:  'Do not use wildcard or $null in this field. Explicitly specify a list for FunctionsToExport.'
            ^
[-] Testing the [ notBuilt ] version of [ Celerium.DattoBCDR ] with [ PSScriptAnalyzer.tests.ps1 ].[ Celerium.DattoBCDR ] module PSScriptAnalyzer tests.[ Celerium.DattoBCDR.psd1 ].Should pass rule [ PSUseToExportFieldsInManifest ] 931ms (928ms|2ms)
 at $result.Line | Should -Be "$($result.ScriptName) - $($result.Line)", C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\PSScriptAnalyzer.tests.ps1:155
 at <ScriptBlock>, C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\PSScriptAnalyzer.tests.ps1:155
 Expected 'Celerium.DattoBCDR.psd1 - 126', but got 126.
[-] Testing the [ notBuilt ] version of [ Celerium.DattoBCDR ] with [ PSScriptAnalyzer.tests.ps1 ].[ Celerium.DattoBCDR ] module PSScriptAnalyzer tests.[ Celerium.DattoBCDR.psd1 ].Should pass rule [ PSUseToExportFieldsInManifest ] 931ms (928ms|2ms)
 at $result.Message | Should -Be "$($result.ScriptName) - $($result.Line)", C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\PSScriptAnalyzer.tests.ps1:156      
 at <ScriptBlock>, C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\PSScriptAnalyzer.tests.ps1:156
 Expected strings to be the same, but they were different.
 Expected length: 29
 Actual length:   90
 Strings differ at index 0.
 Expected: 'Celerium.DattoBCDR.psd1 - 126'
 But was:  'Do not use wildcard or $null in this field. Explicitly specify a list for AliasesToExport.'
            ^
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\ApiKeys\Add-DattoBCDRKey.Tests.ps1 7.31s (5.76s|1.12s)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\ApiKeys\Get-DattoBCDRKey.Tests.ps1 5.75s (3.35s|1.97s)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\ApiKeys\Remove-DattoBCDRKey.Tests.ps1 6.99s (5.07s|1.52s)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\ApiKeys\Test-DattoBCDRKey.Tests.ps1 5.62s (4.17s|1.05s)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\BaseUri\Add-DattoBaseURI.Tests.ps1 5.85s (4.41s|1.09s)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\BaseUri\Get-DattoBaseURI.Tests.ps1 9.14s (6.13s|2.49s)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\BaseUri\Remove-DattoBaseURI.Tests.ps1 5.23s (3.77s|1.07s)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\ModuleSettings\Export-DattoModuleSettings.Tests.ps1 3.89s (2.73s|752ms)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\ModuleSettings\Get-DattoModuleSettings.Tests.ps1 4.61s (3.22s|970ms)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\ModuleSettings\Import-DattoModuleSettings.Tests.ps1 5.44s (3.62s|1.29s)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\ModuleSettings\Initialize-DattoModuleSettings.Tests.ps1 12.85s (10.74s|1.15s)
[+] C:\Users\REDACTED\Documents\GitHub\Celerium.DattoBCDR\tests\Private\ModuleSettings\Remove-DattoModuleSettings.Tests.ps1 5.18s (3.07s|1s)
Tests completed in 538.91s
Tests Passed: 2802, Failed: 1, Skipped: 5, Inconclusive: 0, NotRun: 4
```
